### PR TITLE
Add fixed prop and changable target support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0
+
+- Reactive `target` prop support is added.
+- `Fixed` prop support is added.
+
 ## 0.0.1
 
 - First Ready to use build.

--- a/demo/demos/changableTarget.tsx
+++ b/demo/demos/changableTarget.tsx
@@ -1,0 +1,76 @@
+import { computed, defineComponent, ref } from 'vue';
+
+import { Wowerlay } from '../../src/lib';
+import { defineDemo } from '../helpers';
+
+const Component = defineComponent({
+  name: 'PopoverChangeTarget',
+  setup() {
+    const isOpen = ref(false);
+    const isLeftButtonActive = ref(false);
+
+    const leftButton = ref<HTMLButtonElement>();
+    const rightButton = ref<HTMLButtonElement>();
+
+    const targetEl = computed(() =>
+      isLeftButtonActive.value ? leftButton.value : rightButton.value
+    );
+
+    const toggleVisible = () => (isOpen.value = !isOpen.value);
+    const toggleTargetElement = () => (isLeftButtonActive.value = !isLeftButtonActive.value);
+
+    return {
+      isOpen,
+      targetEl,
+      toggleVisible,
+      leftButton,
+      rightButton,
+      isLeftButtonActive,
+      toggleTargetElement
+    };
+  },
+  render() {
+    return (
+      <>
+        <div
+          style={{
+            width: '300px',
+            margin: '0 auto',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between'
+          }}
+        >
+          <button style={{ color: this.isLeftButtonActive ? 'blue' : 'initial' }} ref="leftButton">
+            Left Target
+          </button>
+          <button style={{ color: this.isLeftButtonActive ? 'initial' : 'blue' }} ref="rightButton">
+            Right Target
+          </button>
+        </div>
+        <br />
+        <button onClick={this.toggleVisible} ref="targetEl">
+          Click to Trigger Popover
+          <Wowerlay
+            onUpdate:visible={(visibility) => (this.isOpen = visibility)}
+            visible={this.isOpen}
+            target={this.targetEl}
+          >
+            <div>
+              <div>Bruh Moment is real</div>
+              <div>Who Whom</div>
+              <br />
+              <div>Hi How</div>
+              <button onClick={this.toggleTargetElement}>Toggle Target</button>
+            </div>
+          </Wowerlay>
+        </button>
+      </>
+    );
+  }
+});
+
+export const Demo = defineDemo({
+  name: 'Changeable Target',
+  component: Component
+});

--- a/demo/demos/fixed.tsx
+++ b/demo/demos/fixed.tsx
@@ -1,0 +1,50 @@
+import { defineComponent, ref } from 'vue';
+
+import { Wowerlay } from '../../src/lib';
+import { defineDemo } from '../helpers';
+
+const Component = defineComponent({
+  name: 'PopoverFixed',
+  setup() {
+    const targetEl = ref<HTMLElement | null>(null);
+    const isOpen = ref(false);
+
+    const handleVisibleChange = (state: boolean) => (isOpen.value = state);
+    const toggleVisible = () => (isOpen.value = !isOpen.value);
+
+    return {
+      isOpen,
+      targetEl,
+      handleVisibleChange,
+      toggleVisible
+    };
+  },
+  render() {
+    return (
+      <button onClick={this.toggleVisible} ref="targetEl">
+        Click to Trigger Popover
+        <Wowerlay
+          fixed
+          onUpdate:visible={this.handleVisibleChange}
+          visible={this.isOpen}
+          target={this.targetEl}
+        >
+          {Array(15)
+            .fill(null)
+            .map((_num, index) => {
+              return (
+                <div>
+                  <b>Hi How are you? {index}</b>
+                </div>
+              );
+            })}
+        </Wowerlay>
+      </button>
+    );
+  }
+});
+
+export const Demo = defineDemo({
+  name: 'Fixed',
+  component: Component
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wowerlay",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "main": "./dist/wowerlay.umd.js",
   "module": "./dist/wowerlay.es.js",
   "types": "./dist/types/lib.d.ts",

--- a/src/components/Wowerlay.tsx
+++ b/src/components/Wowerlay.tsx
@@ -64,7 +64,7 @@ export const Wowerlay = defineComponent({
       <Teleport to={this.toClass}>
         {/*//Todo- Add user made animation support. */}
         <Transition enterActiveClass={cWowerlayAnimEnter} leaveActiveClass={cWowerlayAnimLeave}>
-          {!this.visible ? null : (
+          {this.visible && (
             <WowerlayRenderer {...this.$props} {...this.$attrs}>
               {this.$slots.default?.()}
             </WowerlayRenderer>

--- a/src/components/WowerlayReusables/index.ts
+++ b/src/components/WowerlayReusables/index.ts
@@ -3,7 +3,7 @@ import { PropType } from 'vue';
 export interface WowerlayBaseProps {
   align?: 'auto' | 'top' | 'bottom';
   canLeaveViewport?: boolean;
-  noFollow?: boolean;
+  fixed?: boolean;
   target: any;
   tag?: string;
 }
@@ -16,6 +16,10 @@ export const wowerlayBaseProps = {
   align: {
     default: 'auto',
     type: String as PropType<WowerlayBaseProps['align']>
+  },
+  fixed: {
+    default: false,
+    type: Boolean as PropType<WowerlayBaseProps['fixed']>
   },
   canLeaveViewport: {
     default: false,

--- a/src/styles/Wowerlay.scss
+++ b/src/styles/Wowerlay.scss
@@ -1,21 +1,26 @@
 .wowerlay {
-  $gap: 50px;
-  $varX: var(--wowerlay-x, 0px);
-  $varY: var(--wowerlay-y, 0px);
+  // Varsayılan scrollbar genişliği/yüksekliği / 2
+  $gap: 30px;
+  $horizontalPosition: var(--wowerlay-x);
+  $verticalPosition: var(--wowerlay-y);
+
   position: absolute;
-  display: inline-block;
-  left: 0;
-  top: 0;
+  left: $horizontalPosition;
+  top: $verticalPosition;
+
   z-index: var(--k-z-index, 1500);
-  pointer-events: all !important;
-  transform: translate(#{$varX}, #{$varY});
-  overflow: auto;
+  display: inline-block;
+
   max-width: calc(100vw - #{$gap});
   max-width: calc(#{fill-available} - #{$gap});
   max-width: calc(#{-webkit-fill-available} - #{$gap});
+
   max-height: calc(100vh - #{$gap});
-  max-height: calc(#{fill-available} - 5px);
+  max-height: calc(#{fill-available} - 55px);
   max-height: calc(#{-webkit-fill-available} - #{$gap});
+
+  pointer-events: all !important;
+  overflow: auto;
 }
 
 .wowerlay-anim-enter {


### PR DESCRIPTION
With this PR:
- Wowerlay has ability to watch `target` prop. If `target` prop changes while Wowerlay is open, it follows new target.
- Wowerlay supports `fixed` prop. If `fixed` prop is given and `true` Wowerlay will not follow it's target;