### PR TITLE
Add Demo Build Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .DS_Store
 dist
+dist-demo
 dist-ssr
 *.local
 .vscode

--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ vite.config.ts
 env.d.ts
 test
 demo
+dist-demo

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   ],
   "license": "MIT",
   "scripts": {
-    "dev": "vite",
+    "dev": "cross-env MODE=demo vite",
     "build": "ts-node -T --project tsconfig-build.json scripts/build.ts",
+    "build:demo": "cross-env MODE=demo vite build",
     "release": "ts-node -T --project tsconfig-build.json scripts/release.ts",
     "script:build": "tsc --project tsconfig-build.json && cross-env MODE=production vite build",
     "watch": "cross-env MODE=production vite build --watch"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,10 @@ import { defineConfig } from 'vite';
 import path from 'path';
 
 const root = process.cwd();
-const mode = process.env.MODE as 'production' | undefined;
+const mode = process.env.MODE as 'production' | 'demo';
 
-export default defineConfig({
-  root: mode !== 'production' ? path.join(root, 'demo') : root,
+const productionConfig = defineConfig({
+  root,
   plugins: [
     VueJSX(),
     DTS({
@@ -26,3 +26,13 @@ export default defineConfig({
     }
   }
 });
+
+const demoConfig = defineConfig({
+  root: path.join(root, 'demo'),
+  plugins: [VueJSX()],
+  build: {
+    outDir: path.join(root, 'dist-demo')
+  }
+});
+
+export default mode === 'demo' ? demoConfig : productionConfig;


### PR DESCRIPTION
With this PR:
- Wowerlay can build `Demo` app to `dist-demo` folder. With this feature we will be able to write actions and create automatic build for all pull request, commits and branches.