### PR TITLE
Add Centered Prop and Fix Child Wowerlays Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+- Now Wowerlay will close child Wowerlays on click itself.
+- `centered` prop added, if true wowerlay will be centered.
+
 ## 0.1.0
 
 - `Fixed` prop is added

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ export interface WowerlayBaseProps {
   fixed?: boolean; // if set wowerlay will not update it's position after mount
   target?: HTMLElement; // target element for Wowerlay to follow
   tag?: string; // tagName for Wowerlay container. default: 'div'
+  centered?: boolean; // if given wowerlay will be center itself in current position.
 }
 ```
 

--- a/demo/demos/centered.tsx
+++ b/demo/demos/centered.tsx
@@ -1,0 +1,72 @@
+import { defineComponent, ref } from 'vue';
+import { defineDemo, html } from '../helpers';
+
+import { Wowerlay } from '../../src/lib';
+
+const Component = defineComponent({
+  setup() {
+    const targetEl = ref<HTMLElement>();
+    const isOpen = ref(false);
+
+    const handleVisibleChange = (state: boolean) => (isOpen.value = state);
+    const toggleVisible = () => (isOpen.value = !isOpen.value);
+
+    return {
+      isOpen,
+      targetEl,
+      handleVisibleChange,
+      toggleVisible
+    };
+  },
+  render() {
+    return (
+      <button onClick={this.toggleVisible} ref="targetEl">
+        Click to Show Popover
+        <Wowerlay
+          centered
+          onUpdate:visible={this.handleVisibleChange}
+          visible={this.isOpen}
+          target={this.targetEl}
+        >
+          <div style="max-width: 300px">
+            Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum quam, qui asperiores,
+            sed ipsa fuga, repellendus officiis labore odit temporibus quisquam necessitatibus? Illo
+            vitae quis reprehenderit sequi quae iste, fuga quasi atque et voluptatibus. Debitis,
+            facere, libero voluptate tempore omnis voluptas corporis fugiat sequi quidem cumque
+            quisquam exercitationem a doloribus.
+          </div>
+        </Wowerlay>
+      </button>
+    );
+  }
+});
+
+export const Demo = defineDemo({
+  name: 'Centered',
+  component: Component,
+  template: html`
+    <template>
+      <button @click="visible = !visible" ref="target">
+        Click To Trigger Popover
+
+        <Wowerlay centered v-model:visible="visible" :target="target">
+          <div style="max-width: 300px">
+            Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum quam, qui asperiores,
+            sed ipsa fuga, repellendus officiis labore odit temporibus quisquam necessitatibus? Illo
+            vitae quis reprehenderit sequi quae iste, fuga quasi atque et voluptatibus. Debitis,
+            facere, libero voluptate tempore omnis voluptas corporis fugiat sequi quidem cumque
+            quisquam exercitationem a doloribus.
+          </div>
+        </Wowerlay>
+      </button>
+    </template>
+  `,
+  script: html`
+    <script setup>
+      import { ref } from 'vue';
+
+      const visible = ref(false);
+      const target = ref();
+    </script>
+  `
+});

--- a/demo/demos/fixed.tsx
+++ b/demo/demos/fixed.tsx
@@ -1,10 +1,10 @@
-import { Wowerlay, WowerlayProps } from '../../src/lib';
 import { defineComponent, ref } from 'vue';
 import { defineDemo, html } from '../helpers';
 
-import { WowerlayBaseProps } from '../../src/components/WowerlayReusables';
+import { Wowerlay } from '../../src/lib';
 
 const Component = defineComponent({
+  name: 'PopoverFollow',
   setup() {
     const targetEl = ref<HTMLElement>();
     const isOpen = ref(false);
@@ -12,22 +12,11 @@ const Component = defineComponent({
     const handleVisibleChange = (state: boolean) => (isOpen.value = state);
     const toggleVisible = () => (isOpen.value = !isOpen.value);
 
-    const count = ref(0);
-    const positions = ['bottom', 'right', 'top', 'left'] as WowerlayBaseProps['position'][];
-    const position = ref<WowerlayProps['position']>('bottom');
-
-    const updatePosition = () => {
-      count.value++;
-      position.value = positions[count.value % positions.length];
-    };
-
     return {
       isOpen,
       targetEl,
       handleVisibleChange,
-      toggleVisible,
-      updatePosition,
-      position
+      toggleVisible
     };
   },
   render() {
@@ -35,11 +24,10 @@ const Component = defineComponent({
       <button onClick={this.toggleVisible} ref="targetEl">
         Click to Show Popover
         <Wowerlay
-          centered
+          fixed
           onUpdate:visible={this.handleVisibleChange}
           visible={this.isOpen}
           target={this.targetEl}
-          position={this.position}
         >
           <div style="max-width: 300px">
             Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum quam, qui asperiores,
@@ -47,8 +35,6 @@ const Component = defineComponent({
             vitae quis reprehenderit sequi quae iste, fuga quasi atque et voluptatibus. Debitis,
             facere, libero voluptate tempore omnis voluptas corporis fugiat sequi quidem cumque
             quisquam exercitationem a doloribus.
-            <br />
-            <button onClick={this.updatePosition}>Update position</button>
           </div>
         </Wowerlay>
       </button>
@@ -57,14 +43,14 @@ const Component = defineComponent({
 });
 
 export const Demo = defineDemo({
-  name: 'Centered',
+  name: 'Fixed',
   component: Component,
   template: html`
     <template>
       <button @click="visible = !visible" ref="target">
         Click To Trigger Popover
 
-        <Wowerlay centered v-model:visible="visible" :target="target">
+        <Wowerlay fixed v-model:visible="visible" :target="target">
           <div style="max-width: 300px">
             Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum quam, qui asperiores,
             sed ipsa fuga, repellendus officiis labore odit temporibus quisquam necessitatibus? Illo

--- a/demo/demos/nested.tsx
+++ b/demo/demos/nested.tsx
@@ -1,0 +1,110 @@
+import { defineComponent, ref } from 'vue';
+import { defineDemo, html } from '../helpers';
+
+import { Wowerlay } from '../../src/lib';
+
+const Component = defineComponent({
+  name: 'PopoverFollow',
+  setup() {
+    const targetEl = ref<HTMLElement>();
+    const isOpen = ref(false);
+
+    const handleVisibleChange = (state: boolean) => (isOpen.value = state);
+    const toggleVisible = () => (isOpen.value = !isOpen.value);
+
+    const secondTarget = ref<HTMLElement>();
+    const secondPopoverVisibility = ref(false);
+
+    return {
+      isOpen,
+      targetEl,
+      handleVisibleChange,
+      toggleVisible,
+      secondPopoverVisibility,
+      secondTarget
+    };
+  },
+  render() {
+    return (
+      <button onClick={this.toggleVisible} ref="targetEl">
+        Click to Show Popover
+        <Wowerlay
+          onUpdate:visible={this.handleVisibleChange}
+          visible={this.isOpen}
+          target={this.targetEl}
+        >
+          <div style="max-width: 300px">
+            Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum quam, qui asperiores,
+            sed ipsa fuga, repellendus officiis labore odit temporibus quisquam necessitatibus? Illo
+            vitae quis reprehenderit sequi quae iste, fuga quasi atque et voluptatibus. Debitis,
+            facere, libero voluptate tempore omnis voluptas corporis fugiat sequi quidem cumque
+            quisquam exercitationem a doloribus.
+            <br />
+            <button onClick={() => (this.secondPopoverVisibility = true)} ref="secondTarget">
+              Toggle Second Popover
+              <Wowerlay
+                onUpdate:visible={(v) => (this.secondPopoverVisibility = v)}
+                visible={this.secondPopoverVisibility}
+                target={this.secondTarget}
+              >
+                <div style="max-width: 300px">
+                  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum quam, qui
+                  asperiores, sed ipsa fuga, repellendus officiis labore odit temporibus quisquam
+                  necessitatibus? Illo vitae quis reprehenderit sequi quae iste, fuga quasi atque et
+                  voluptatibus. Debitis, facere, libero voluptate tempore omnis voluptas corporis
+                  fugiat sequi quidem cumque quisquam exercitationem a doloribus.
+                </div>
+              </Wowerlay>
+            </button>
+          </div>
+        </Wowerlay>
+      </button>
+    );
+  }
+});
+
+export const Demo = defineDemo({
+  name: 'Nested',
+  component: Component,
+  template: html`
+    <template>
+      <button @click="visible = !visible" ref="target">
+        Click To Trigger Popover
+
+        <Wowerlay v-model:visible="visible" :target="target">
+          <div style="max-width: 300px">
+            Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum quam, qui asperiores,
+            sed ipsa fuga, repellendus officiis labore odit temporibus quisquam necessitatibus? Illo
+            vitae quis reprehenderit sequi quae iste, fuga quasi atque et voluptatibus. Debitis,
+            facere, libero voluptate tempore omnis voluptas corporis fugiat sequi quidem cumque
+            quisquam exercitationem a doloribus.
+
+            <button @click="secondVisible = !secondVisible" ref="secondTarget">
+              Toggle Second Popover
+              <Wowerlay v-model:visible="secondVisible" :target="secondTarget">
+                <div style="max-width: 300px">
+                  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Rerum quam, qui
+                  asperiores, sed ipsa fuga, repellendus officiis labore odit temporibus quisquam
+                  necessitatibus? Illo vitae quis reprehenderit sequi quae iste, fuga quasi atque et
+                  voluptatibus. Debitis, facere, libero voluptate tempore omnis voluptas corporis
+                  fugiat sequi quidem cumque quisquam exercitationem a doloribus.
+                </div>
+              </Wowerlay>
+            </button>
+          </div>
+        </Wowerlay>
+      </button>
+    </template>
+  `,
+  script: html`
+    <script setup>
+      import { ref } from 'vue';
+
+      const visible = ref(false);
+      const secondVisible = ref(false);
+
+      const secondTarget = ref();
+      const target = ref();
+    </script>
+  `
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wowerlay",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "./dist/wowerlay.umd.js",
   "module": "./dist/wowerlay.es.js",
   "types": "./dist/types/lib.d.ts",

--- a/src/components/Wowerlay.tsx
+++ b/src/components/Wowerlay.tsx
@@ -1,4 +1,16 @@
-import { PropType, Teleport, Transition, defineComponent, ref, watch } from 'vue';
+import {
+  InjectionKey,
+  PropType,
+  Teleport,
+  Transition,
+  defineComponent,
+  inject,
+  onBeforeUnmount,
+  provide,
+  reactive,
+  ref,
+  watch
+} from 'vue';
 import { WowerlayBaseProps, wowerlayBaseProps } from './WowerlayReusables';
 import { cWowerlayAnimEnter, cWowerlayAnimLeave, cWowerlayContainer } from '../consts';
 
@@ -19,6 +31,12 @@ const Emits = {
   'update:visible': (value: boolean): any => typeof value === 'boolean'
 } as const;
 
+interface ParentWowerlayContext {
+  onClose: (hook: () => void) => void;
+}
+
+const ParentWowerlayContextInjectionKey: InjectionKey<ParentWowerlayContext> = Symbol();
+
 export const Wowerlay = defineComponent({
   name: 'Wowerlay',
   inheritAttrs: false,
@@ -29,17 +47,30 @@ export const Wowerlay = defineComponent({
   emits: Emits,
   setup(props, { emit }) {
     const { onWindowClick } = useWowerlayContext();
+    const parentWowerlay = inject(ParentWowerlayContextInjectionKey, null);
+
+    const childrenWowerlayHooks = reactive([]) as Function[];
     const canClose = ref(false);
 
-    const toClass = `.${cWowerlayContainer}`;
+    const closeChildWowerlays = () => {
+      childrenWowerlayHooks.forEach((v) => v());
+    };
 
-    onWindowClick(() => {
+    const close = () => {
       if (!props.visible) return;
 
       if (canClose.value) {
+        closeChildWowerlays();
+        childrenWowerlayHooks.length = 0;
         emit('update:visible', false);
       }
-    });
+    };
+
+    parentWowerlay?.onClose(close);
+    const handleWowerlayClick = closeChildWowerlays;
+
+    onWindowClick(close);
+    onBeforeUnmount(close);
 
     watch(
       () => props.visible,
@@ -54,18 +85,30 @@ export const Wowerlay = defineComponent({
       }
     );
 
+    provide(ParentWowerlayContextInjectionKey, {
+      onClose(hook) {
+        childrenWowerlayHooks.push(hook);
+      }
+    });
+
     return {
-      toClass,
-      canClose
+      canClose,
+      handleWowerlayClick
     };
   },
   render() {
+    const toClass = `.${cWowerlayContainer}`;
+
     return (
-      <Teleport to={this.toClass}>
+      <Teleport to={toClass}>
         {/*// Todo: Add user made animation support. */}
         <Transition enterActiveClass={cWowerlayAnimEnter} leaveActiveClass={cWowerlayAnimLeave}>
           {this.visible && (
-            <WowerlayRenderer {...this.$props} {...this.$attrs}>
+            <WowerlayRenderer
+              {...this.$props}
+              {...this.$attrs}
+              onWowerlayClick={this.handleWowerlayClick}
+            >
               {this.$slots.default?.()}
             </WowerlayRenderer>
           )}

--- a/src/components/WowerlayReusables/index.ts
+++ b/src/components/WowerlayReusables/index.ts
@@ -8,12 +8,17 @@ export interface WowerlayBaseProps {
   fixed?: boolean;
   target?: HTMLElement;
   tag?: string;
+  centered?: boolean;
 }
 
 export const wowerlayBaseProps = {
   target: {
     required: true,
     type: null as unknown as PropType<WowerlayBaseProps['target']>
+  },
+  centered: {
+    default: false,
+    type: Boolean as PropType<WowerlayBaseProps['centered']>
   },
   fixed: {
     default: false,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- `centered` prop is added. If set Wowerlay will be centered to in current position `horizontal or vertical`.
- Now when clicked parent Wowerlay, child Wowerlays will be closed.


* **What is the current behavior?** (You can also link to an open issue here)
Currently you cannot close child Wowerlays if you click inside parent Wowerlay.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
